### PR TITLE
Update dependencies to use php 8/laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
   "require": {
     "php": "^8.0",
     "ext-json": "*",
-    "erusev/parsedown-extra": "^0.7.1",
+    "erusev/parsedown-extra": "^0.8.1",
     "illuminate/support": "^9.0",
     "illuminate/http": "^9.0",
-    "mblsolutions/inspireddeck-php-laravel": "1.*"
+    "mblsolutions/inspireddeck-php-laravel": "^1.5|^2.0"
   },
   "require-dev": {
-    "mockery/mockery": "~1.0",
+    "mockery/mockery": "^1.5",
     "orchestra/testbench": "^7.14",
-    "phpunit/phpunit": "^8.0|^9.0"
+    "phpunit/phpunit": "^9.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,17 @@
     }
   ],
   "require": {
-    "php": ">=7.1.0",
+    "php": "^8.0",
     "ext-json": "*",
     "erusev/parsedown-extra": "^0.7.1",
-    "illuminate/support": "~5.7.0|~5.8.0|^6.0|^7.0|^8.0",
-    "illuminate/http": "~5.7.0|~5.8.0|^6.0|^7.0|^8.0",
+    "illuminate/support": "^9.0",
+    "illuminate/http": "^9.0",
     "mblsolutions/inspireddeck-php-laravel": "1.*"
   },
   "require-dev": {
     "mockery/mockery": "~1.0",
-    "orchestra/testbench": "^4.0",
-    "phpunit/phpunit": "^8.0"
+    "orchestra/testbench": "^7.14",
+    "phpunit/phpunit": "^8.0|^9.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Removing support for older versions of PHP, laravel and other dependencies. Should have major bump in version (v3.x) to avoid issues with current live site.