### PR TITLE
Hotfix for wiz report on vulnerability CVE-2025-12816

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "vue-datetime": "^1.0.0-beta.10",
     "vue-infinite-loading": "^2.4.4",
     "weekstart": "^1.0.0"
+  },
+  "resolutions": {
+    "node-forge": "1.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3809,10 +3809,10 @@ node-addon-api@^7.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
   integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
 
-node-forge@^1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
-  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+node-forge@1.4.0, node-forge@^1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.4.0.tgz#1c7b7d8bdc2d078739f58287d589d903a11b2fc2"
+  integrity sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==
 
 node-libs-browser@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
Bump version to 1.4.0 for vulnerability CVE-2025-12816